### PR TITLE
upgrade 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 
+Deprecation note
+================
+
+Since ES6/7 with babel+webpack/browserefy becomes usefull this days RequireJS looks a bit outdated.
+
+ReactJS community have a lot of sample code written in ES6/7 in isomorphic style.
+
+
 Boilerplate for Karma-runner + mocha + chai + requirejs
 =======================================================
 

--- a/js/spec/sample_spec.js
+++ b/js/spec/sample_spec.js
@@ -1,5 +1,5 @@
 
-define(['chai'], function(chai) {
+define(['chai', 'sinon'], function(chai, sinon) {
   var expect = chai.expect;
 
   describe('bootstrap', function() {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,7 +20,6 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      'node_modules/sinon/pkg/sinon.js',                    // sinon will be accessable from global context
       {pattern: 'node_modules/**/*.js', included: false},   // allow to load any *.js from node_modules by karma web-server
 
       'test/test-main.js',
@@ -38,7 +37,8 @@ module.exports = function(config) {
 
     // test results reporter to use
     // possible values: 'dots', 'progress', 'junit', 'growl', 'coverage'
-    reporters: ['progress', 'mp3', 'html'],
+    // reporters: ['progress', 'mp3', 'html'],
+    reporters: ['progress'],
 
     // uncomment this for redefine mp3-reporter sound files
     // ====================================================
@@ -78,7 +78,7 @@ module.exports = function(config) {
     // - Safari (only Mac; has to be installed with `npm install karma-safari-launcher`)
     // - PhantomJS
     // - IE (only Windows; has to be installed with `npm install karma-ie-launcher`)
-    browsers: ['Chrome'],
+    browsers: [],
 
 
     // If browser does not capture in given timeout [ms], kill it

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "boilerplate-karma-mocha-chai-requirejs",
   "description": "Redy to use test-framework boilerplate for karma-runner, mocha, chai, requirejs",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "author": "Konstantin Ivanov [x@ES] <KEIvanov@gmail.com>",
   "license": "MIT",
 
@@ -19,15 +19,20 @@
   ],
 
   "dependencies": {
-    "requirejs": "latest"
+    "requirejs": "~2.1.20"
   },
   "devDependencies": {
-    "karma": "latest",
-    "karma-mocha": "latest",
-    "chai": "latest",
-    "sinon": "latest",
-    "karma-html-reporter": "latest",
-    "karma-mp3-reporter": "latest"
+    "karma": "~0.13.10",
+    "karma-mocha": "~0.2.0",
+    "karma-requirejs": "~0.2.2",
+    "mocha": "~2.3.3",
+    "chai": "~3.3.0",
+    "sinon": "~1.17.1"
+  },
+
+  "__disabledDependencies": {
+    "karma-html-reporter": "~0.2.6",
+    "karma-mp3-reporter": "~1.0.0"
   },
 
   "homepage": "https://github.com/x2es/boilerplate-karma-mocha-chai-requirejs",

--- a/test/test-main.js
+++ b/test/test-main.js
@@ -30,7 +30,8 @@
       baseUrl: baseUrl,
 
       paths: {
-        'chai': 'node_modules/chai/chai'
+        'chai':  'node_modules/chai/chai',
+        'sinon': 'node_modules/sinon/pkg/sinon'
       },
 
       // ask Require.js to load these files (all our tests)


### PR DESCRIPTION
added deprecation note
sinon used as AMD module
reporters `karma-html-reporter` and `karma-mp3-reporter` disabled by
default (has issues)
fixed dependencies versions
